### PR TITLE
Normalize the direction of reaction nodes

### DIFF
--- a/metabolike/db/metacyc.py
+++ b/metabolike/db/metacyc.py
@@ -503,7 +503,7 @@ class MetaDB(BaseDB):
              COLLECT(gp.displayName) as symbol, COLLECT(grdf.ncbigene) AS ncbi
         RETURN {
           id: id(r), name: r.displayName, ec: ec, gibbs: r.gibbs0,
-          direction: r.reactionDirection, reversible: r.reversible,
+          direction: r.reactionDirection,
           genes: {symbol: symbol, ncbi: ncbi}
         };
             """,

--- a/metabolike/db/metacyc.py
+++ b/metabolike/db/metacyc.py
@@ -431,6 +431,27 @@ class MetaDB(BaseDB):
             val=attr_val,
         )
 
+    def fix_reaction_direction(self):
+        """
+        Seems like ``listOfReactants`` in the SBML file are always the true
+        reactants in irreversible reactions, no matter if they are under
+        ``LEFT`` or ``RIGHT`` in the dat file. Since the reaction nodes were all
+        populated using the SBML file, we can say all reactions are either
+        reversible or go from left to right.
+        """
+        self.write(
+            """
+            MATCH (r:Reaction {reactionDirection: 'right_to_left'})
+            SET r.reactionDirection = 'left_to_right'
+            """
+        )
+        self.write(
+            """
+            MATCH (r:Reaction {reactionDirection: 'physiol_right_to_left'})
+            SET r.reactionDirection = 'physiol_left_to_right'
+            """
+        )
+
     def delete_bad_reaction_nodes(self):
         """
         Delete reaction nodes with non-canonical mcIds and all their relationships.

--- a/metabolike/parser/metacyc.py
+++ b/metabolike/parser/metacyc.py
@@ -210,6 +210,9 @@ class Metacyc:
                     # Correct composite reactions
                     self.db.set_composite_reaction_labels()
 
+                # Fix the direction of reactions
+                self.db.fix_reaction_direction()
+
             # SMILES reactions
             if self.input_files["atom_mapping"]:
                 logger.info("Adding SMILES to reactions")

--- a/metabolike/parser/metacyc.py
+++ b/metabolike/parser/metacyc.py
@@ -316,7 +316,6 @@ class Metacyc:
             # Basic properties
             props = {
                 "displayName": r.getName(),
-                "reversible": r.getReversible(),
                 "fast": r.getFast(),
             }
             self.db.create_node("Reaction", mcid, props)


### PR DESCRIPTION
- All reactions are either reversible or go from left to right (physiologically).
- The `reversible` property field in `Reaction` nodes are removed. This comes from SBML files and often differ from `reactionDirection` in reaction.dat files, and the latter is in accordance with the arrow directions on the website.