### PR TITLE
Test all parser code

### DIFF
--- a/metabolike/parser/metacyc.py
+++ b/metabolike/parser/metacyc.py
@@ -930,7 +930,7 @@ class MetacycParser(SBMLParser):
             s = s[m.end() :].strip()
 
         # Final cleanup
-        cpd = cpd.replace("|", "")
+        cpd = cpd.replace("|", "").replace('"', "")
         pathways = [
             p.replace('"', "") for p in pathways if (" " not in p) and p.isupper()
         ]  # remove frame IDs and quoted annotations

--- a/metabolike/parser/metacyc.py
+++ b/metabolike/parser/metacyc.py
@@ -746,8 +746,8 @@ class MetacycParser(SBMLParser):
         # Clean up props before writing to graph
         node["props"] = self._clean_props(
             node["props"],
-            num_fields=[snake_to_camel(x) for x in prop_num_keys],
-            enum_fields=[snake_to_camel(x) for x in prop_enum_keys],
+            num_fields=prop_num_keys,
+            enum_fields=prop_enum_keys,
         )
 
         return node
@@ -767,14 +767,14 @@ class MetacycParser(SBMLParser):
             A dictionary with normalized properties.
         """
         for f in num_fields:
-            if f in props:
-                props[f] = float(props[f])
+            if (k := snake_to_camel(f)) in props:
+                props[k] = float(props[k])
 
         enum_pattern = re.compile(r"\W+")
         for f in enum_fields:
-            if f in props:
-                props[f] = props[f].replace("-", "_").lower()
-                props[f] = enum_pattern.sub("", props[f])
+            if (k := snake_to_camel(f)) in props:
+                props[k] = props[k].replace("-", "_").lower()
+                props[k] = enum_pattern.sub("", props[k])
 
         return props
 

--- a/metabolike/parser/metacyc.py
+++ b/metabolike/parser/metacyc.py
@@ -252,7 +252,8 @@ class MetacycParser(SBMLParser):
         self._fix_composite_reaction_nodes(comp_rxn_nodes)
 
         # Annotate regular pathway nodes
-        pw_nodes = self._fix_pathway_nodes(pw_nodes)
+        all_rxns = set(self.db.get_all_nodes("Reaction", "name"))
+        pw_nodes = self._fix_pathway_nodes(pw_nodes, all_rxns)
         self.db.create_nodes(
             "Pathway",
             pw_nodes,
@@ -368,7 +369,7 @@ class MetacycParser(SBMLParser):
         # Fix the direction of newly-added reactions
         self.db.fix_reaction_direction()
 
-    def _fix_pathway_nodes(self, pw_nodes: List[Dict[str, Any]]):
+    def _fix_pathway_nodes(self, pw_nodes: List[Dict[str, Any]], all_rxns: Set[str]):
         """
         Some fields in the list of ``Pathway`` nodes require preprocessing
          before being fed into the database. Specifically:
@@ -386,8 +387,8 @@ class MetacycParser(SBMLParser):
 
         Args:
             pw_nodes: Output of :meth:`_collect_pathways_dat_nodes`.
+            all_rxns: All valid reaction names.
         """
-        all_rxns = set(self.db.get_all_nodes("Reaction", "name"))
         for i, n in enumerate(pw_nodes):
             if predecessors := n.get("predecessors"):
                 predecessors: List[str]

--- a/tests/parser/test_brenda.py
+++ b/tests/parser/test_brenda.py
@@ -3,14 +3,46 @@ from pathlib import Path
 import pandas as pd
 import pandas.testing as pdt
 import pytest
-from metabolike.parser.brenda import (_get_parser_from_field, _read_brenda,
-                                      _text_to_tree)
+from metabolike.parser.brenda import (
+    _get_parser_from_field,
+    _read_brenda,
+    _text_to_tree,
+    parse_brenda,
+)
+
+brenda_txt = Path("tests/data/brenda_test.txt")
+brenda_cache = brenda_txt.with_suffix(".csv")
+brenda_parsed = brenda_txt.with_suffix(".json")
 
 
 @pytest.fixture
 def brenda_data():
-    df = _read_brenda(Path("tests/data/brenda_test.txt"))
-    return df
+    return _read_brenda(brenda_txt)
+
+
+def test_read_brenda_cache():
+    with pytest.raises(ValueError):
+        _read_brenda(Path("tests/data/fake_file.txt"))
+
+    df = _read_brenda(brenda_txt, cache=True)
+    assert brenda_cache.is_file()
+
+    df2 = _read_brenda(brenda_txt, cache=True)
+    pdt.assert_frame_equal(df, df2)
+
+    brenda_cache.unlink()
+
+
+def test_parse_brenda():
+    ec = ["1.1.1.1", "6.3.5.8"]
+    d1 = parse_brenda(brenda_txt, cache=True, ec_nums=ec)
+    assert brenda_parsed.is_file()
+
+    d2 = parse_brenda(brenda_txt, cache=True, ec_nums=ec)
+    assert d1 == d2
+
+    brenda_cache.unlink()
+    brenda_parsed.unlink()
 
 
 def test_read_brenda(brenda_data):

--- a/tests/parser/test_metacyc.py
+++ b/tests/parser/test_metacyc.py
@@ -102,13 +102,14 @@ def test_dat_entry_to_node(mc: MetacycParser, rxn_dat: Dict[str, List[List[str]]
             "REACTION-BALANCE-STATUS",
         },
         props_list_keys={"TYPES"},
+        node_str_keys={"EC-NUMBER"},
         node_list_keys={"IN-PATHWAY", "NONEXISTENT-KEY"},
         prop_num_keys={"GIBBS-0"},
         prop_enum_keys={"REACTION-BALANCE-STATUS", "REACTION-DIRECTION"},
     )
 
     assert isinstance(n, dict)
-    assert set(n.keys()) == {"name", "props", "inPathway"}
+    assert set(n.keys()) == {"name", "props", "inPathway", "ecNumber"}
     assert set(n["props"].keys()) == {
         "canonicalId",
         "gibbs0",
@@ -190,7 +191,7 @@ def test_parse_pathway_links(mc: MetacycParser):
     s = "(PYRUVATE  ))"
     with pytest.raises(ValueError):
         mc._parse_pathway_links(s)
-    s = "(PYRUVATE  (XXX)"
+    s = "(PYRUVATE (XXX)"
     with pytest.raises(ValueError):
         mc._parse_pathway_links(s)
 
@@ -320,6 +321,9 @@ def test_collect_atom_mapping_dat_nodes(mc: MetacycParser):
     assert len(nodes) == 2
     assert "props" in nodes[0]
     assert "smilesAtomMapping" in nodes[0]["props"]
+
+    _ = mc._collect_atom_mapping_dat_nodes({"RXN-000"}, smiles)
+    assert mc.missing_ids["atom_mappings"] == {"RXN-000"}
 
 
 def test_collect_compounds_dat_nodes(mc: MetacycParser):

--- a/tests/parser/test_metacyc.py
+++ b/tests/parser/test_metacyc.py
@@ -1,0 +1,235 @@
+from pathlib import Path
+from typing import List
+
+import pytest
+from metabolike.parser import MetacycParser
+
+dat_path = Path("tests/data/")
+
+
+@pytest.fixture(name="mc")
+def mc_parser():
+    # No need to pass an actual database to the parser
+    return MetacycParser(
+        None,
+        sbml=dat_path / "metabolic-reactions.sbml",
+        reactions=dat_path / "reactions.dat",
+        atom_mapping=dat_path / "atom-mappings-smiles.dat",
+        pathways=dat_path / "pathways.dat",
+        compounds=dat_path / "compounds.dat",
+        publications=dat_path / "pubs.dat",
+        classes=dat_path / "classes.dat",
+    )
+
+
+@pytest.fixture
+def rxn_ids(mc: MetacycParser):
+    doc = mc._read_sbml(mc.sbml_file)
+    model = doc.getModel()
+    return [x.getMetaId() for x in model.getListOfReactions()]
+
+
+def test_read_dat_file(mc: MetacycParser):
+    citations = mc._read_dat_file(dat_path / "pubs.dat")
+
+    assert isinstance(citations, dict)
+    assert len(citations) == 105
+
+    cit = citations["PUB-ARCHMICR161460"]
+    assert isinstance(cit, list)
+    assert all(isinstance(x, list) for x in cit)
+    assert all(len(x) == 2 for x in cit)
+
+
+def test_find_rxn_canonical_id(mc: MetacycParser, rxn_ids: List[str]):
+    # Valid reaction IDs
+    assert mc._find_rxn_canonical_id("RXN-15513", rxn_ids) == "RXN-15513"
+    assert mc._find_rxn_canonical_id("6PFRUCTPHOS-RXN", rxn_ids) == "6PFRUCTPHOS-RXN"
+    assert (
+        mc._find_rxn_canonical_id(
+            "F16BDEPHOS-RXN[CCO-CYTOSOL]-FRUCTOSE-16-DIPHOSPHATE/WATER//FRUCTOSE-6P/Pi.59.",
+            rxn_ids,
+        )
+        == "F16BDEPHOS-RXN"
+    )
+
+    # Invalid reaction IDs
+    with pytest.raises(ValueError):
+        mc._find_rxn_canonical_id("RXN0", rxn_ids)
+
+    # Return whatever if found in rxn_ids
+    assert mc._find_rxn_canonical_id("RXN0", ["RXN0"] + rxn_ids) == "RXN0"
+
+
+def test_clean_props(mc: MetacycParser):
+    props = {
+        "name": "RXN-15513",
+        "gibbs0": "-1.3200073",
+        "reactionBalanceStatus": ":BALANCED",
+    }
+
+    assert mc._clean_props(
+        props, num_fields=["GIBBS-0"], enum_fields=["REACTION-BALANCE-STATUS"]
+    ) == {
+        "name": "RXN-15513",
+        "gibbs0": -1.3200073,
+        "reactionBalanceStatus": "balanced",
+    }
+
+
+def test_dat_entry_to_node(mc: MetacycParser):
+    node = {"name": "RXN-15513", "props": {"canonicalId": "RXN-15513"}}
+    rxn_dat = mc._read_dat_file(dat_path / "reactions.dat")
+    lines = rxn_dat["RXN-15513"]
+
+    n = mc._dat_entry_to_node(node, lines)
+    assert n == node
+
+    n = mc._dat_entry_to_node(
+        node,
+        lines,
+        props_str_keys={
+            "GIBBS-0",
+            "REACTION-DIRECTION",
+            "REACTION-BALANCE-STATUS",
+        },
+        props_list_keys={"TYPES"},
+        node_list_keys={"IN-PATHWAY", "NONEXISTENT-KEY"},
+        prop_num_keys={"GIBBS-0"},
+        prop_enum_keys={"REACTION-BALANCE-STATUS", "REACTION-DIRECTION"},
+    )
+
+    assert isinstance(n, dict)
+    assert set(n.keys()) == {"name", "props", "inPathway"}
+    assert set(n["props"].keys()) == {
+        "canonicalId",
+        "gibbs0",
+        "reactionDirection",
+        "reactionBalanceStatus",
+        "types",
+    }
+
+    assert isinstance(n["inPathway"], list)
+    assert len(n["inPathway"]) == 7
+    assert isinstance(n["props"]["gibbs0"], float)
+    assert n["props"]["reactionDirection"] == "reversible"
+
+
+def test_name_to_metaid(mc: MetacycParser):
+    assert mc._name_to_metaid("RXN-15513") == "RXN__45__15513"
+    assert mc._name_to_metaid("1.1.1.1-RXN") == "_1__46__1__46__1__46__1__45__RXN"
+    assert mc._name_to_metaid("FE2+-RXN") == "FE2__45__RXN"
+
+
+def test_parse_pathway_predecessors(mc: MetacycParser):
+    all_rxns = {"RXN-13760", "RXN-19880", "PGLUCISOM-RXN"}
+
+    # single pathway ID
+    assert mc._parse_pathway_predecessors("PWY-1", all_rxns) == {}
+
+    # single reaction ID
+    assert mc._parse_pathway_predecessors("(RXN-13760)", all_rxns) == {}
+    assert mc._parse_pathway_predecessors("(RXN-1)", all_rxns) == {}
+
+    # Normal cases
+    pred = mc._parse_pathway_predecessors("(RXN-19880 RXN-13760)", all_rxns)
+    assert pred == {"r1": "RXN-19880", "r2": ["RXN-13760"]}
+    pred = mc._parse_pathway_predecessors('("RXN-19880" "RXN-13760")', all_rxns)
+    assert pred == {"r1": "RXN-19880", "r2": ["RXN-13760"]}
+    s = "(RXN-19880 RXN-13760 PGLUCISOM-RXN)"
+    assert mc._parse_pathway_predecessors(s, all_rxns) == {
+        "r1": "RXN-19880",
+        "r2": ["RXN-13760", "PGLUCISOM-RXN"],
+    }
+
+    # r1 not in all_rxns
+    pred = mc._parse_pathway_predecessors("(RXN-1 RXN-13760)", all_rxns)
+    assert pred == {}
+
+    # r2 not in all_rxns
+    pred = mc._parse_pathway_predecessors("(RXN-19880 RXN-13760 RXN-1)", all_rxns)
+    assert pred == {"r1": "RXN-19880", "r2": ["RXN-13760"]}
+
+
+def test_parse_reaction_layout(mc: MetacycParser):
+    s = (
+        "(PGLUCISOM-RXN "
+        "(:LEFT-PRIMARIES D-glucopyranose-6-phosphate) "
+        "(:DIRECTION :L2R) "
+        "(:RIGHT-PRIMARIES FRUCTOSE-6P))"
+    )
+
+    assert mc._parse_reaction_layout(f"{s} ") == ("", {})
+    rxn_id, d = mc._parse_reaction_layout(s)
+    assert rxn_id == "PGLUCISOM-RXN"
+    assert d == {
+        "reactants": ["D-glucopyranose-6-phosphate"],
+        "products": ["FRUCTOSE-6P"],
+    }
+    s = s.replace(":L2R", ":R2L")
+    _, d = mc._parse_reaction_layout(s)
+    assert d == {
+        "reactants": ["FRUCTOSE-6P"],
+        "products": ["D-glucopyranose-6-phosphate"],
+    }
+
+
+def test_parse_pathway_links(mc: MetacycParser):
+    # invalid string
+    s = "PYRUVATE ALANINE-SYN2-PWY"
+    assert mc._parse_pathway_links(s) == ("", [], "")
+
+    s = "(PYRUVATE  ))"
+    with pytest.raises(ValueError):
+        mc._parse_pathway_links(s)
+    s = "(PYRUVATE  (XXX)"
+    with pytest.raises(ValueError):
+        mc._parse_pathway_links(s)
+
+    # simplest case
+    s = "(PYRUVATE ALANINE-SYN2-PWY)"
+    cpd, pathways, direction = mc._parse_pathway_links(s)
+    assert cpd == "PYRUVATE"
+    assert pathways == ["ALANINE-SYN2-PWY"]
+    assert direction == "OUTGOING"
+
+    # multiple pathways
+    s = "(PYRUVATE PWY-5481 PWY-7351)"
+    cpd, pathways, direction = mc._parse_pathway_links(s)
+    assert cpd == "PYRUVATE"
+    assert pathways == ["PWY-5481", "PWY-7351"]
+    assert direction == "OUTGOING"
+
+    # directed link
+    s = "(GLYCEROL (TRANS-RXN-131 . :INCOMING))"
+    cpd, pathways, direction = mc._parse_pathway_links(s)
+    assert cpd == "GLYCEROL"
+    assert pathways == ["TRANS-RXN-131"]
+    assert direction == "INCOMING"
+
+    s = '("D-glucopyranose" PWY-6724 (RXN-14352 . :INCOMING))'
+    cpd, pathways, direction = mc._parse_pathway_links(s)
+    assert cpd == "D-glucopyranose"
+    assert pathways == ["PWY-6724", "RXN-14352"]
+    assert direction == "INCOMING"
+
+    # frame ID
+    s = "(|Starch| PWY-6724)"
+    cpd, pathways, direction = mc._parse_pathway_links(s)
+    assert cpd == "Starch"
+    assert pathways == ["PWY-6724"]
+    assert direction == "OUTGOING"
+
+    s = "(G3P |Biosynthesis|)"
+    cpd, pathways, direction = mc._parse_pathway_links(s)
+    assert cpd == "G3P"
+    assert pathways == []
+    assert direction == "OUTGOING"
+
+    # random string
+    s = '(ACETYL-P "conversion to acetate")'
+    cpd, pathways, direction = mc._parse_pathway_links(s)
+    assert cpd == "ACETYL-P"
+    assert pathways == []
+    assert direction == "OUTGOING"
+

--- a/tests/parser/test_sbml.py
+++ b/tests/parser/test_sbml.py
@@ -6,6 +6,8 @@ from metabolike.parser import SBMLParser
 @pytest.fixture
 def sbml_parser():
     # No need to pass an actual database to the parser
+    with pytest.raises(ValueError):
+        SBMLParser(None, None)
     return SBMLParser(None, "tests/data/metabolic-reactions.sbml")
 
 
@@ -133,4 +135,12 @@ def test_split_uri(sbml_parser: SBMLParser):
     assert sbml_parser._split_uri("http://identifiers.org/ec-code/1.1.1.1") == (
         "ec-code",
         "1.1.1.1",
+    )
+    assert sbml_parser._split_uri("http://identifiers.org/biocyc/META:RXN-15513") == (
+        "biocyc",
+        "RXN-15513",
+    )
+    assert sbml_parser._split_uri("http://identifiers.org/kegg.reaction/R00199") == (
+        "kegg-reaction",
+        "R00199",
     )

--- a/tests/parser/test_sbml.py
+++ b/tests/parser/test_sbml.py
@@ -1,0 +1,136 @@
+import pytest
+from libsbml import Model, SBMLDocument
+from metabolike.parser import SBMLParser
+
+
+@pytest.fixture
+def sbml_parser():
+    # No need to pass an actual database to the parser
+    return SBMLParser(None, "tests/data/metabolic-reactions.sbml")
+
+
+@pytest.fixture
+def sbml_model(sbml_parser: SBMLParser):
+    doc = sbml_parser._read_sbml(sbml_parser.sbml_file)
+    assert isinstance(doc, SBMLDocument)
+
+    model = doc.getModel()
+    assert isinstance(model, Model)
+
+    return model
+
+
+def test_collect_compartments(sbml_parser: SBMLParser, sbml_model: Model):
+    assert sbml_model.getNumCompartments() == 33
+    compartments = sbml_model.getListOfCompartments()
+    nodes = sbml_parser._collect_compartments(compartments)
+
+    assert isinstance(nodes, list)
+    assert len(nodes) == 33
+    assert all("metaId" in n for n in nodes)
+    assert all("props" in n for n in nodes)
+    assert nodes[-1] == {"metaId": "x", "props": {"name": "CCO-PEROX-LUM"}}
+
+
+def test_collect_compounds(sbml_parser: SBMLParser, sbml_model: Model):
+    assert sbml_model.getNumSpecies() == 45
+    species = sbml_model.getListOfSpecies()
+    nodes = sbml_parser._collect_compounds(species)
+
+    assert isinstance(nodes, list)
+    assert len(nodes) == 45
+    assert all("metaId" in n for n in nodes)
+    assert all("props" in n for n in nodes)
+    assert all("compartment" in n for n in nodes)
+    assert nodes[0] == {
+        "metaId": "G3P_c",
+        "props": {
+            "name": "3-phospho-D-glycerate",
+            "chemicalFormula": "C3H4O7P",
+            "boundaryCondition": False,
+            "hasOnlySubstanceUnits": False,
+            "constant": False,
+        },
+        "compartment": "c",
+        "rdf": [
+            {
+                "bioQual": "is",
+                "rdf": {
+                    "biocyc": "G3P",
+                    "inchikey": "OSJPPGNTCRNQQC-UWTATZPHSA-K",
+                    "chebi": "58272",
+                    "cas": "820-11-1",
+                    "hmdb": "HMDB60180",
+                    "pubchemCompound": "25245548",
+                    "keggCompound": "C00197",
+                    "metabolights": "MTBLC58272",
+                },
+            },
+            {"bioQual": "hasProperty", "rdf": {"sbo": "0000247"}},
+        ],
+    }
+
+
+def test_collect_gene_products(sbml_parser: SBMLParser, sbml_model: Model):
+    fbc = sbml_model.getPlugin("fbc")
+    assert fbc.getNumGeneProducts() == 118
+    gene_products = fbc.getListOfGeneProducts()
+    nodes = sbml_parser._collect_gene_products(gene_products)
+
+    assert isinstance(nodes, list)
+    assert len(nodes) == 118
+    assert all("metaId" in n for n in nodes)
+    assert all("props" in n for n in nodes)
+    assert all("rdf" in n for n in nodes)
+
+    assert nodes[0] == {
+        "metaId": "G_G_3784",
+        "props": {"name": "apgM", "label": "G-3784"},
+        "rdf": [
+            {
+                "bioQual": "is",
+                "rdf": {
+                    "uniprot": "Q9X295",
+                },
+            },
+            {
+                "bioQual": "isEncodedBy",
+                "rdf": {"biocyc": "G-3784", "ncbigene": "897849"},
+            },
+        ],
+    }
+
+
+def test_collect_reactions(sbml_parser: SBMLParser, sbml_model: Model):
+    assert sbml_model.getNumReactions() == 12
+    reactions = sbml_model.getListOfReactions()
+    nodes = sbml_parser._collect_reactions(reactions)
+
+    assert isinstance(nodes, list)
+    assert len(nodes) == 12
+    assert all("metaId" in n for n in nodes)
+    assert all("props" in n for n in nodes)
+    assert all("rdf" in n for n in nodes)
+    assert all("reactants" in n for n in nodes)
+    assert all("products" in n for n in nodes)
+
+    assert nodes[0] == {
+        "metaId": "RXN__45__15513",
+        "props": {"name": "RXN-15513", "fast": False},
+        "rdf": [
+            {"bioQual": "is", "rdf": {"biocyc": "RXN-15513", "ecCode": ["5.4.2.11"]}}
+        ],
+        "reactants": [
+            {"cpdId": "_2__45__PG_c", "props": {"stoichiometry": 1.0, "constant": True}}
+        ],
+        "products": [
+            {"cpdId": "G3P_c", "props": {"stoichiometry": 1.0, "constant": True}}
+        ],
+    }
+
+
+def test_split_uri(sbml_parser: SBMLParser):
+    assert sbml_parser._split_uri("http://identifiers.org/ec-code/1.1.1.1") == (
+        "ec-code",
+        "1.1.1.1",
+    )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,105 @@
+import pytest
+from metabolike.utils import (
+    add_kv_to_dict,
+    chunk,
+    generate_gene_reaction_rule,
+    snake_to_camel,
+    validate_path,
+)
+
+
+def test_validate_path():
+    assert validate_path(None) is None
+    f = validate_path("tests/data/pubs.dat")
+
+    assert f.is_absolute()
+    assert f.name == "pubs.dat"
+
+    with pytest.raises(FileNotFoundError):
+        validate_path("tests/data/pubs.dat.nonexistent")
+
+
+def test_chunk():
+    res = list(chunk([1, 2, 3, 4], 2))
+    assert res == [[1, 2], [3, 4]]
+    res = list(chunk([1, 2, 3, 4, 5], 2))
+    assert res == [[1, 2], [3, 4], [5]]
+
+
+def test_snake_to_camel():
+    assert snake_to_camel("test_snake_case", "_") == "testSnakeCase"
+    assert snake_to_camel("ec-code") == "ecCode"
+    assert snake_to_camel("ec-code", ".") == "ec-code"
+    assert snake_to_camel("kegg.reaction", ".") == "keggReaction"
+
+
+def test_add_kv_to_dict():
+    d = {}
+    d = add_kv_to_dict(d, "k1", "v1", as_list=False)
+    assert d == {"k1": "v1"}
+
+    d = add_kv_to_dict(d, "k1", "v2", as_list=False)
+    assert d == {"k1": "v2"}
+
+    d = add_kv_to_dict(d, "k2", "v1", as_list=True)
+    assert d == {"k1": "v2", "k2": ["v1"]}
+
+    d = add_kv_to_dict(d, "k2", "v2", as_list=True)
+    assert d == {"k1": "v2", "k2": ["v1", "v2"]}
+
+
+def test_generate_gene_reaction_rule():
+    dummy_node = {"label": "Reaction", "name": "rxn"}
+    gp_nodes = [
+        {
+            "label": "GeneProduct",
+            "metaId": f"gene__45__{i}",
+            "name": f"gene-{i}",
+        }
+        for i in range(4)
+    ]
+
+    gp_complex = {
+        "label": "GeneProductComplex",
+        "metaId": "complex__45__1",
+        "name": "complex-1",
+    }
+
+    gp_set = {
+        "label": "GeneProductSet",
+        "metaId": "set__45__1",
+        "name": "set-1",
+    }
+
+    # Single gene
+    rule = [(dummy_node, gp_nodes[0])]
+    assert generate_gene_reaction_rule(rule) == "gene-0"
+
+    # Single complex
+    rule = [
+        (dummy_node, gp_complex),
+        (gp_complex, gp_nodes[0]),
+        (gp_complex, gp_nodes[1]),
+    ]
+    assert generate_gene_reaction_rule(rule) == "gene-0 and gene-1"
+
+    # Single set
+    rule = [
+        (dummy_node, gp_set),
+        (gp_set, gp_nodes[0]),
+        (gp_set, gp_nodes[1]),
+    ]
+    assert generate_gene_reaction_rule(rule) == "gene-0 or gene-1"
+
+    # Complex within set
+    rule = [
+        (dummy_node, gp_set),
+        (gp_set, gp_nodes[0]),
+        (gp_set, gp_nodes[1]),
+        (gp_set, gp_complex),
+        (gp_complex, gp_nodes[2]),
+        (gp_complex, gp_nodes[3]),
+    ]
+    assert (
+        generate_gene_reaction_rule(rule) == "gene-0 or gene-1 or ( gene-2 and gene-3 )"
+    )


### PR DESCRIPTION
* test: SBML, MetaCyc, and BRENDA parsers.
* test: `utils` functions.
* fix: remove quoted compound IDs in pathway links.
* refactor: put all database methods into `*_to_graph()` methods.